### PR TITLE
fix: simplify validation reports

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -177,6 +177,9 @@ func (e *Executor) verifySubjectAgainstReferrers(ctx context.Context, task *exec
 						return errSubjectPruned
 					}
 
+					// it is possible that one or some verifiers' reports in the
+					// results and the next verifier triggers the subject pruned state,
+					// so the results are not empty.
 					artifactReport := &ValidationReport{
 						Subject:  artifact,
 						Results:  results,
@@ -189,7 +192,6 @@ func (e *Executor) verifySubjectAgainstReferrers(ctx context.Context, task *exec
 				return err
 			}
 
-			// Create artifact report for successful verification
 			artifactReport := &ValidationReport{
 				Subject:  artifact,
 				Results:  results,
@@ -197,7 +199,6 @@ func (e *Executor) verifySubjectAgainstReferrers(ctx context.Context, task *exec
 			}
 			artifactReports = append(artifactReports, artifactReport)
 
-			// Add a new task for the verified referrer artifact
 			referrerArtifact := task.artifact
 			referrerArtifact.Reference = referrer.Digest.String()
 			newTasks = append(newTasks, &executorTask{

--- a/executor.go
+++ b/executor.go
@@ -188,7 +188,6 @@ func (e *Executor) verifySubjectAgainstReferrers(ctx context.Context, task *exec
 					artifactReports = append(artifactReports, artifactReport)
 					return errSubjectPruned
 				}
-
 				return err
 			}
 

--- a/executor.go
+++ b/executor.go
@@ -171,21 +171,26 @@ func (e *Executor) verifySubjectAgainstReferrers(ctx context.Context, task *exec
 	err := e.Store.ListReferrers(ctx, artifact, referenceTypes, func(referrers []ocispec.Descriptor) error {
 		for _, referrer := range referrers {
 			results, err := e.verifyArtifact(ctx, repo, task.artifactDesc, referrer, evaluator)
-			artifactReport := &ValidationReport{
-				Subject:  artifact,
-				Results:  results,
-				Artifact: referrer,
-			}
 			if err != nil {
 				if errors.Is(err, errSubjectPruned) && len(results) > 0 {
 					// it is possible that one or some verifiers' reports in the
 					// results and the next verifier triggers the subject pruned state,
 					// so the results are not empty.
+					artifactReport := &ValidationReport{
+						Subject:  artifact,
+						Results:  results,
+						Artifact: referrer,
+					}
 					artifactReports = append(artifactReports, artifactReport)
 				}
 				return err
 			}
 
+			artifactReport := &ValidationReport{
+				Subject:  artifact,
+				Results:  results,
+				Artifact: referrer,
+			}
 			artifactReports = append(artifactReports, artifactReport)
 
 			referrerArtifact := task.artifact

--- a/executor_test.go
+++ b/executor_test.go
@@ -905,7 +905,7 @@ func TestValidateArtifact(t *testing.T) {
 								Description: validMessage2,
 							},
 						},
-						ArtifactReports: []*ValidationReport{{}},
+						ArtifactReports: []*ValidationReport{},
 					},
 				}},
 			wantErr: false,
@@ -1121,16 +1121,8 @@ func TestValidateArtifact_SBoMNotConfigured_WithThresholdPolicy(t *testing.T) {
 		ArtifactReports: []*ValidationReport{
 			{
 				// empty result for SBoM as no verifier is configured
-				Results: []*VerificationResult{},
-				ArtifactReports: []*ValidationReport{
-					{
-						// empty result for SBoM's sig as no parent node
-						Results:         []*VerificationResult{},
-						ArtifactReports: []*ValidationReport{
-							// should no sub-reports for testArtifact5 as has been pruned
-						},
-					},
-				},
+				Results:         []*VerificationResult{},
+				ArtifactReports: []*ValidationReport{},
 			},
 			{
 				Results: []*VerificationResult{


### PR DESCRIPTION
## What this PR does:

If validation result is empty and confirmed to be pruned by policy enforcer, we don't need to keep the empty report in the verification report. This PR simplified the verification report with empty result.

**Please check the following list**:

- [x]  Does the affected code have corresponding tests, e.g. unit test?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?
