### PR TITLE
fix: fix commit logic and calculateDecision algorithm

### DIFF
--- a/threshold_policy_enforcer.go
+++ b/threshold_policy_enforcer.go
@@ -133,8 +133,7 @@ type evaluationNode struct {
 	childNodes map[int][]*evaluationNode
 
 	// commited indicates whether more child (virtual) nodes will be added to
-	// this node. If set to true, the node is finalized and no more child
-	// nodes will be added to it.
+	// this node. If set to true, no more child nodes will be added to it.
 	commited bool
 }
 

--- a/threshold_policy_enforcer.go
+++ b/threshold_policy_enforcer.go
@@ -106,7 +106,8 @@ func (r *ThresholdPolicyRule) compile(ruleID int) (set.Set[string], int) {
 
 // evaluationNode holds the statistics for a policy rule during evaluation.
 // An evaluationNode is regarded as a virtual node if it corresponds to a rule
-// without Verifier set.
+// without Verifier set. A virtual node will set artifactDigest to empty since
+// it doesn't correspond to a specific artifact.
 type evaluationNode struct {
 	// rule is the policy rule for this node.
 	rule *ThresholdPolicyRule
@@ -131,7 +132,9 @@ type evaluationNode struct {
 	// by rule ID.
 	childNodes map[int][]*evaluationNode
 
-	// commited indicates whether the node is commited or not.
+	// commited indicates whether more child (virtual) nodes will be added to
+	// this node. If set to true, the node is finalized and no more child
+	// nodes will be added to it.
 	commited bool
 }
 
@@ -148,6 +151,8 @@ func (n *evaluationNode) addChildNode(rule *ThresholdPolicyRule, artifactDigest 
 		node.childVirtualNodes = make(map[int]*evaluationNode)
 	}
 
+	// A nested rule with verifier set could match multiple artifacts of the
+	// same artifactType.
 	n.childNodes[rule.ruleID] = append(n.childNodes[rule.ruleID], node)
 	return node
 }
@@ -181,18 +186,30 @@ func (n *evaluationNode) calculateDecision() thresholdPolicyDecision {
 	}
 
 	successfulRuleCount := 0
+	undeterminedRuleCount := 0
 	for _, nodes := range n.childNodes {
 		// validate each rule
+		successfuleRuleFound := false
+		undeterminedRuleFound := false
 		for _, node := range nodes {
 			if node.ruleDecision == thresholdPolicyDecisionAllow {
-				successfulRuleCount++
-				break
+				successfuleRuleFound = true
+			} else if node.ruleDecision == thresholdPolicyDecisionUndetermined {
+				undeterminedRuleFound = true
 			}
+		}
+		if successfuleRuleFound {
+			successfulRuleCount++
+		}
+		if undeterminedRuleFound {
+			undeterminedRuleCount++
 		}
 	}
 	for _, node := range n.childVirtualNodes {
 		if node.ruleDecision == thresholdPolicyDecisionAllow {
 			successfulRuleCount++
+		} else if node.ruleDecision == thresholdPolicyDecisionUndetermined {
+			undeterminedRuleCount++
 		}
 	}
 
@@ -202,23 +219,10 @@ func (n *evaluationNode) calculateDecision() thresholdPolicyDecision {
 	}
 	if successfulRuleCount >= threshold {
 		n.ruleDecision = thresholdPolicyDecisionAllow
-	}
-	if n.isCommited() {
+	} else if n.commited && undeterminedRuleCount == 0 {
 		n.ruleDecision = thresholdPolicyDecisionDeny
 	}
 	return n.ruleDecision
-}
-
-// isCommited checks if the node or any of its ancestors are commited.
-// In single goroutine mode, we only need to check the commited field.
-// In multi goroutine mode, we need to track referrers listed before committed.
-func (n *evaluationNode) isCommited() bool {
-	for node := n; node != nil; node = node.subjectNode {
-		if node.commited {
-			return true
-		}
-	}
-	return false
 }
 
 // refreshAncestorsDecision refreshes the decision for all ancestors.

--- a/threshold_policy_enforcer_test.go
+++ b/threshold_policy_enforcer_test.go
@@ -422,6 +422,10 @@ func TestEvaluation(t *testing.T) {
 		t.Fatalf("unexpected error adding result: %v", err)
 	}
 
+	if err = evaluator.Commit(ctx, imageDigest); err != nil {
+		t.Fatalf("unexpected error committing: %v", err)
+	}
+
 	state, err = evaluator.Pruned(ctx, sbomDigest1, notationDigest2, notationVerifier1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -444,6 +448,10 @@ func TestEvaluation(t *testing.T) {
 		t.Fatalf("unexpected error adding result: %v", err)
 	}
 
+	if err = evaluator.Commit(ctx, sbomDigest1); err != nil {
+		t.Fatalf("unexpected error committing: %v", err)
+	}
+
 	state, err = evaluator.Pruned(ctx, sbomDigest2, notationDigest3, notationVerifier1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -463,15 +471,15 @@ func TestEvaluation(t *testing.T) {
 		t.Fatalf("expected subject pruned state, got %v", state)
 	}
 
+	if err = evaluator.Commit(ctx, sbomDigest2); err != nil {
+		t.Fatalf("unexpected error committing: %v", err)
+	}
+
 	decision, err = evaluator.Evaluate(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error evaluating: %v", err)
 	}
 	if decision != true {
 		t.Fatalf("expected decision true, got %v", decision)
-	}
-
-	if err = evaluator.Commit(ctx, imageDigest); err != nil {
-		t.Fatalf("unexpected error committing: %v", err)
 	}
 }


### PR DESCRIPTION
## What this PR does / why we need it:

Problem:
The current isCommited returns true when an evaluationNode got everything(no more undetermined child nodes) to make a decision. However, the initial objective of the Commit field is to indicate there is no more referrers or new nodes will be added to the evaluationNode.

Fix:
Correct the definition and implementation of the commited field. And in `calculateDecision` method, it should consider if there is new undetermined child nodes, if so, we cannot make a decision even though it's commited.

**Which issue(s) this PR resolves**

<!-- Optional, in `resolves #<issue number>(, resolves #<issue_number>, ...)` format, will close the issue(s) when PR gets merged). -->

Resolves #

**Please check the following list**:

- [x]  Does the affected code have corresponding tests, e.g. unit test?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?
