### PR TITLE
build: bump up go version to 1.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       checks: write
     strategy:
       matrix:
-        go-version: ['1.22', '1.23']
+        go-version: ['1.23', '1.24']
       fail-fast: true
     steps:
       - name: Checkout

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        go-version: ['1.22', '1.23']
+        go-version: ['1.23', '1.24']
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/notaryproject/ratify-go
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/opencontainers/go-digest v1.0.0


### PR DESCRIPTION
## What this PR does / why we need it:

Bump up go version to 1.24 and update CI pipelines
